### PR TITLE
🥲 remove CNCF Nantes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Vous pouvez rejoindre la communauté tech nantaise et échanger avec nous sur Sl
 - [Nantes.rb](./nantes-rb/)
 - [React Nantes](./react-nantes/)
 
-## 🐘 Les événements Nantais
+
+## 🐘 Les communautés Nantaises à la recherche d'organisateur·rice
+- [CNCF Nantes](./cncf-nantes/)
+
+
+## 📅 Les événements Nantais
 
 - [DevFest Nantes](./devfest-nantes/)
 - [Web2Day](https://web2day.co/)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Vous pouvez rejoindre la communauté tech nantaise et échanger avec nous sur Sl
 
 - [AgileNantes](./agilenantes/)
 - [Blockchain et société](./blockchain-et-societe/)
-- [CNCF Nantes](./cncf-nantes/)
 - [CocoaHeads Nantes](./cocoanantes/)
 - [Flupa Nantes](./flupa/)
 - [Flutter Grand Ouest](./flutter-grand-ouest/)

--- a/cncf-nantes/README.md
+++ b/cncf-nantes/README.md
@@ -1,4 +1,4 @@
-# CNCF Nantes (**Meetup inactif depuis l'été 2021**)
+# CNCF Nantes (_**Meetup inactif depuis l'été 2021**_)
 
 |                                |     |
 | ------------------------------ | --- |

--- a/cncf-nantes/README.md
+++ b/cncf-nantes/README.md
@@ -1,4 +1,4 @@
-# CNCF Nantes 
+# CNCF Nantes (**Meetup inactif depuis l'été 2021**)
 
 |                                |     |
 | ------------------------------ | --- |


### PR DESCRIPTION
La page meetup de la CNCF Nantes n'est plus disponible.

Mais dans ce cas, devrions nous la supprimer du repo, ou bien laisser la page ouverte pour des éventuelles reprises par des personnes qui verraient ce meetup inactif ?